### PR TITLE
Update Variable Sets doc about argument conflicts

### DIFF
--- a/website/docs/r/variable_set.html.markdown
+++ b/website/docs/r/variable_set.html.markdown
@@ -28,7 +28,6 @@ resource "tfe_workspace" "test" {
 resource "tfe_variable_set" "test" {
   name          = "Test Varset"
   description   = "Some description."
-  global        = false
   organization  = tfe_organization.test.name
   workspace_ids = [tfe_workspace.test.id]
 }
@@ -111,7 +110,7 @@ The following arguments are supported:
 * `description` - (Optional) Description of the variable set.
 * `global` - (Optional) Whether or not the variable set applies to all workspaces in the organization. Defaults to `false`.
 * `organization` - (Required) Name of the organization.
-* `workspace_ids` - (Optional) IDs of the workspaces that use the variable set.
+* `workspace_ids` - (Optional) IDs of the workspaces that use the variable set. Must not be set if `global` is set.
 
 ## Attributes Reference
 


### PR DESCRIPTION
The provider will raise an error if you have both `global` and `workspace_ids` arguments set, regardless if `global` is set to `false` as coded here in the provider itself: `https://github.com/hashicorp/terraform-provider-tfe/blob/main/tfe/resource_tfe_variable_set.go#L39`

Locally we did this
```
data "tfe_workspace_ids" "test" {
  names = ["*"]
  organization = data.tfe_organization.this.name
}

resource "tfe_variable_set" "test" {
  name         = "Test Variable Set"
  description  = "Test variable set applied to all workspaces."
  global       = false
  organization = data.tfe_organization.this.name
  workspace_ids = values(data.tfe_workspace_ids.test.ids)
}
```

Resulting in this error
```
│ Error: Conflicting configuration arguments
│ 
│   with tfe_variable_set.test,
│   on variable-set-test.tf line 9, in resource "tfe_variable_set" "test":
│    9:   global       = false
│ 
│ "global": conflicts with workspace_ids
```